### PR TITLE
S3-Box-3 assistant use media player instead of speaker

### DIFF
--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -45,6 +45,7 @@ esphome:
     priority: 600
     then:
       - script.execute: draw_display
+      - media_player.volume_set: 80% # temporary volume adjustment
       - delay: 30s
       - if:
           condition:
@@ -74,11 +75,11 @@ psram:
   speed: 80MHz
 
 external_components:
-  - source: github://pr#5230
-    components: esp_adf
-    refresh: 0s
-  - source: github://jesserockz/esphome-components
-    components: [file]
+  - source:
+      type: git
+      url: https://github.com/gnumpi/esphome_audio
+      ref: dev-next
+    components: [ adf_pipeline, i2s_audio ]
     refresh: 0s
 
 api:
@@ -171,16 +172,75 @@ light:
     restore_mode: RESTORE_DEFAULT_ON
     default_transition_length: 250ms
 
-esp_adf:
-  board: esp32s3box3
+i2c:
+  - id: bus_a
+    sda: GPIO08
+    scl: GPIO18
+    scan: false
+    sda_pullup_enabled: true
+    scl_pullup_enabled: true
+    frequency: 100kHz
+
+i2s_audio:
+  - id: i2s_shared
+    i2s_lrclk_pin: GPIO45
+    i2s_bclk_pin: GPIO17
+    i2s_mclk_pin: GPIO2
+    access_mode: duplex
+
+adf_pipeline:
+  - platform: i2s_audio
+    type: audio_out
+    id: adf_i2s_out
+    i2s_audio_id: i2s_shared
+    i2s_dout_pin: GPIO15
+    adf_alc: false
+    dac:
+      i2c_id: bus_a
+      model: es8311
+      address: 0x18
+      enable_pin: GPIO46
+    sample_rate: 16000
+    bits_per_sample: 16bit
+    fixed_settings: true
+
+  - platform: i2s_audio
+    type: audio_in
+    id: adf_i2s_in
+    i2s_audio_id: i2s_shared
+    i2s_din_pin: GPIO16
+    pdm: false
+    adc:
+      i2c_id: bus_a
+      model: es7210
+      address: 0x40
+    sample_rate: 16000
+    bits_per_sample: 16bit
+    fixed_settings: true
+
+media_player:
+  - platform: adf_pipeline
+    id: adf_media_player
+    name: Player
+    internal: false
+    keep_pipeline_alive: true
+    announcement_audio:
+      sample_rate: 24000
+      bits_per_sample: 16
+      num_channels: 1
+    pipeline:
+      - self
+      - resampler
+      - adf_i2s_out
 
 microphone:
-  - platform: esp_adf
-    id: box_mic
-
-speaker:
-  - platform: esp_adf
-    id: box_speaker
+  - platform: adf_pipeline
+    id: adf_microphone
+    keep_pipeline_alive: true
+    pipeline:
+      - adf_i2s_in
+      - resampler
+      - self
 
 micro_wake_word:
   model: ${micro_wake_word_model}
@@ -190,12 +250,12 @@ micro_wake_word:
 
 voice_assistant:
   id: va
-  microphone: box_mic
-  speaker: box_speaker
+  microphone: adf_microphone
+  media_player: adf_media_player
   noise_suppression_level: 2
   auto_gain: 31dBFS
   volume_multiplier: 2.0
-  vad_threshold: 3
+  # vad_threshold: 3
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_listening_phase_id};
     - text_sensor.template.publish:
@@ -217,12 +277,15 @@ voice_assistant:
     - text_sensor.template.publish:
         id: text_response
         state: !lambda return x;
-  on_tts_stream_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: draw_display
-  on_tts_stream_end:
+  on_tts_end:
+    - delay: 1s
+    - wait_until:
+        media_player.is_idle:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
     - script.execute: draw_display
+
   on_end:
     - if:
         condition:
@@ -280,11 +343,13 @@ voice_assistant:
         condition:
           switch.is_on: timer_ringing
         then:
-          - lambda: id(box_speaker).play(id(timer_finished_wave_file), sizeof(id(timer_finished_wave_file)));
+          # - media_player.play_media: !lambda return id(timer_finished_wave_file)
+          - media_player.play_media: 'http://homeassistant.local:8123/local/esphome/timer_finished.mp3'
           - delay: 1s
+          - wait_until:
+              media_player.is_idle:
     - wait_until:
-        not:
-          speaker.is_playing:
+        media_player.is_idle:
     - switch.turn_off: timer_ringing
     - script.execute: start_voice_assistant
     - script.execute: draw_display
@@ -709,9 +774,9 @@ color:
   - id: paused_timer_color
     hex: "3b89e3"
 
-file:
-  - id: timer_finished_wave_file
-    file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav
+# file:
+#   - id: timer_finished_wave_file
+#     file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav
 
 spi:
   - id: spi_bus

--- a/wake-word-voice-assistant/esp32-s3-box-3.yaml
+++ b/wake-word-voice-assistant/esp32-s3-box-3.yaml
@@ -45,7 +45,6 @@ esphome:
     priority: 600
     then:
       - script.execute: draw_display
-      - media_player.volume_set: 80% # temporary volume adjustment
       - delay: 30s
       - if:
           condition:
@@ -274,6 +273,7 @@ voice_assistant:
         state: !lambda return x;
     - script.execute: draw_display
   on_tts_start:
+    - script.execute: set_speech_volume
     - text_sensor.template.publish:
         id: text_response
         state: !lambda return x;
@@ -284,6 +284,7 @@ voice_assistant:
     - wait_until:
         media_player.is_idle:
     - lambda: id(voice_assistant_phase) = ${voice_assist_idle_phase_id};
+    - script.execute: reset_volume
     - script.execute: draw_display
 
   on_end:
@@ -334,6 +335,7 @@ voice_assistant:
   on_timer_finished:
     - script.execute: stop_voice_assistant
     - lambda: id(voice_assistant_phase) = ${voice_assist_timer_finished_phase_id};
+    - script.execute: set_alarm_volume
     - switch.turn_on: timer_ringing
     - script.execute: draw_display
     - wait_until:
@@ -343,13 +345,13 @@ voice_assistant:
         condition:
           switch.is_on: timer_ringing
         then:
-          # - media_player.play_media: !lambda return id(timer_finished_wave_file)
           - media_player.play_media: 'http://homeassistant.local:8123/local/esphome/timer_finished.mp3'
           - delay: 1s
           - wait_until:
               media_player.is_idle:
     - wait_until:
         media_player.is_idle:
+    - script.execute: reset_volume
     - switch.turn_off: timer_ringing
     - script.execute: start_voice_assistant
     - script.execute: draw_display
@@ -540,6 +542,48 @@ script:
             - voice_assistant.stop:
             - micro_wake_word.stop:
       - lambda: id(voice_assistant_phase) = ${voice_assist_not_ready_phase_id};
+  - id: set_speech_volume
+    then:
+      - script.execute: save_volume
+      - media_player.volume_set: !lambda return 0.5 + id(speech_volume).state * 0.005;
+  - id: set_alarm_volume
+    then:
+      - script.execute: save_volume
+      - media_player.volume_set: !lambda return id(alarm_volume).state * 0.01;
+  - id: save_volume
+    then:
+      - globals.set:
+          id: media_volume
+          value: !lambda return id(adf_media_player).volume * 100;
+  - id: reset_volume
+    then:
+      - media_player.volume_set: !lambda return id(media_volume) * 0.01;
+number:
+  - platform: template
+    name: Speech volume
+    id: speech_volume
+    min_value: 0.0
+    max_value: 100.0
+    initial_value: 100.0
+    step: 1.0
+    optimistic: true
+    restore_value: true
+    entity_category: config
+    icon: "mdi:volume-high"
+    mode: slider
+
+  - platform: template
+    name: Alarm volume
+    id: alarm_volume
+    min_value: 0.0
+    max_value: 100.0
+    initial_value: 100.0
+    step: 1.0
+    optimistic: true
+    restore_value: true
+    entity_category: config
+    icon: "mdi:volume-high"
+    mode: slider
 
 switch:
   - platform: template
@@ -663,6 +707,9 @@ globals:
   - id: global_is_timer
     type: bool
     restore_value: false
+  - id: media_volume
+    type: float
+    restore_value: false
 
 image:
   - file: ${error_illustration_file}
@@ -773,10 +820,6 @@ color:
     hex: "26ed3a"
   - id: paused_timer_color
     hex: "3b89e3"
-
-# file:
-#   - id: timer_finished_wave_file
-#     file: https://github.com/esphome/firmware/raw/main/voice-assistant/sounds/timer_finished.wav
 
 spi:
   - id: spi_bus


### PR DESCRIPTION
This PR allows the S3-Box-3 assistant to use [gnumpi's media_player component](https://github.com/gnumpi/esphome_audio) rather than a speaker.

This gives control over the volume, and exposes the media player as an entity in HA to allow TTS and media playback.

It also adds two volume entities controlling the speech and alarm volumes independently. The underlying media_player volume is restored after speech/alarm. 